### PR TITLE
Support for Doctrine/ORM 2 is still required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
     "laminas/laminas-test": "^4.0",
-    "doctrine/orm": "^3.0",
+    "doctrine/orm": "^2.13.3 || ^3.0",
     "pdepend/pdepend": "^2.10",
     "friendsofphp/php-cs-fixer": "^3.8",
     "squizlabs/php_codesniffer": "^3.7",


### PR DESCRIPTION
Support for Doctrine/ORM 2 is still required